### PR TITLE
Fix Implementation of Labels for Form Control

### DIFF
--- a/src/Blocks/FormControl.purs
+++ b/src/Blocks/FormControl.purs
@@ -40,6 +40,7 @@ type FormControlProps =
   { helpText :: Maybe String
   , label :: String
   , valid :: Maybe ValidationErrors
+  , inputId :: String
   }
 
 formControl
@@ -50,8 +51,8 @@ formControl
 formControl props html =
   HH.div
     [ HP.classes formControlClasses ]
-    [ HH.span
-      [ HP.class_ (HH.ClassName "w-full") ]
+    [ HH.label
+      [ HP.class_ (HH.ClassName "w-full"), HP.for props.inputId ]
       [ label props.label
       , HH.div
           [ HP.class_ (HH.ClassName "my-1") ]

--- a/src/Blocks/FormControl.purs
+++ b/src/Blocks/FormControl.purs
@@ -53,12 +53,11 @@ formControl props html =
     [ HP.classes formControlClasses ]
     [ HH.label
       [ HP.class_ (HH.ClassName "w-full"), HP.for props.inputId ]
-      [ label props.label
-      , HH.div
-          [ HP.class_ (HH.ClassName "my-1") ]
-          [ html ]
-      , helpText props.valid props.helpText
-      ]
+      [ label props.label ]
+    , HH.div
+      [ HP.class_ (HH.ClassName "my-1") ]
+      [ html ]
+    , helpText props.valid props.helpText
     ]
   where
     helpText (Just errors) _ =

--- a/src/Components/Typeahead/Typeahead.purs
+++ b/src/Components/Typeahead/Typeahead.purs
@@ -61,14 +61,15 @@ defSingle :: ∀ o item source err eff m
   . MonadAff (TA.Effects eff) m
  => Eq item
  => Show err
- => Array item
+ => String
+ -> Array item
  -> RenderTypeaheadItem item
  -> TA.TypeaheadInput o item source err (TA.Effects eff) m
-defSingle xs { toStrMap, renderFuzzy, renderItem } =
+defSingle inputId xs { toStrMap, renderFuzzy, renderItem } =
   { items: TA.Sync xs
   , search: Nothing
   , initialSelection: TA.One Nothing
-  , render: renderTA renderFuzzy renderItem
+  , render: renderTA inputId renderFuzzy renderItem
   , config: defConfig toStrMap
   }
 
@@ -77,15 +78,16 @@ defLimit :: ∀ o item source err eff m
   . MonadAff (TA.Effects eff) m
  => Eq item
  => Show err
- => Int
+ => String
+ -> Int
  -> Array item
  -> RenderTypeaheadItem item
  -> TA.TypeaheadInput o item source err (TA.Effects eff) m
-defLimit n xs { toStrMap, renderFuzzy, renderItem } =
+defLimit inputId n xs { toStrMap, renderFuzzy, renderItem } =
   { items: TA.Sync xs
   , search: Nothing
   , initialSelection: TA.Limit n []
-  , render: renderTA renderFuzzy renderItem
+  , render: renderTA inputId renderFuzzy renderItem
   , config: defConfig toStrMap
   }
 
@@ -95,14 +97,15 @@ defMulti :: ∀ o item source err eff m
   . MonadAff (TA.Effects eff) m
  => Eq item
  => Show err
- => Array item
+ => String
+ -> Array item
  -> RenderTypeaheadItem item
  -> TA.TypeaheadInput o item source err (TA.Effects eff) m
-defMulti xs { toStrMap, renderFuzzy, renderItem } =
+defMulti inputId xs { toStrMap, renderFuzzy, renderItem } =
   { items: TA.Sync xs
   , search: Nothing
   , initialSelection: TA.Many []
-  , render: renderTA renderFuzzy renderItem
+  , render: renderTA inputId renderFuzzy renderItem
   , config: defConfig toStrMap
   }
 
@@ -111,14 +114,15 @@ defAsyncSingle :: ∀ o item source err eff m
   . MonadAff (TA.Effects eff) m
   => Eq item
   => Show err
-  => source
+  => String
+  -> source
   -> RenderTypeaheadItem item
   -> TA.TypeaheadInput o item source err (TA.Effects eff) m
-defAsyncSingle source { toStrMap, renderFuzzy, renderItem } =
+defAsyncSingle inputId source { toStrMap, renderFuzzy, renderItem } =
   { items: TA.Async source NotAsked
   , search: Nothing
   , initialSelection: TA.One Nothing
-  , render: renderTA renderFuzzy renderItem
+  , render: renderTA inputId renderFuzzy renderItem
   , config: defConfig toStrMap
   }
 
@@ -127,14 +131,15 @@ defAsyncMulti :: ∀ o item source err eff m
   . MonadAff (TA.Effects eff) m
  => Eq item
  => Show err
- => source
+ => String
+ -> source
  -> RenderTypeaheadItem item
  -> TA.TypeaheadInput o item source err (TA.Effects eff) m
-defAsyncMulti source { toStrMap, renderFuzzy, renderItem } =
+defAsyncMulti inputId source { toStrMap, renderFuzzy, renderItem } =
   { items: TA.Async source NotAsked
   , search: Nothing
   , initialSelection: TA.Many []
-  , render: renderTA renderFuzzy renderItem
+  , render: renderTA inputId renderFuzzy renderItem
   , config: defConfig toStrMap
   }
 
@@ -144,14 +149,15 @@ defContAsyncMulti :: ∀ o item source err eff m
   . MonadAff (TA.Effects eff) m
  => Eq item
  => Show err
- => source
+ => String
+ -> source
  -> RenderTypeaheadItem item
  -> TA.TypeaheadInput o item source err (TA.Effects eff) m
-defContAsyncMulti source { toStrMap, renderFuzzy, renderItem } =
+defContAsyncMulti inputId source { toStrMap, renderFuzzy, renderItem } =
   { items: TA.ContinuousAsync (Milliseconds 500.0) "" source NotAsked
   , search: Nothing
   , initialSelection: TA.Many []
-  , render: renderTA renderFuzzy renderItem
+  , render: renderTA inputId renderFuzzy renderItem
   , config: contAsyncConfig toStrMap
   }
 
@@ -191,11 +197,12 @@ type TAParentHTML o item source err eff m
 renderTA :: ∀ o item source err eff m
   . MonadAff (TA.Effects eff) m
  => Eq item
- => (Fuzzy item -> HH.PlainHTML)
+ => String
+ -> (Fuzzy item -> HH.PlainHTML)
  -> (item -> HH.PlainHTML)
  -> TA.TypeaheadState item source err
  -> TAParentHTML o item source err (TA.Effects eff) m
-renderTA renderFuzzy renderSelection st =
+renderTA inputId renderFuzzy renderSelection st =
   HH.div_
   [ renderSelections
   , HH.slot'
@@ -234,6 +241,8 @@ renderTA renderFuzzy renderSelection st =
     renderSearch sst = HH.div_
       [ Input.input
         ( S.getInputProps
-          [ HP.placeholder "Type to search...", HP.value sst.search ]
+          [ HP.placeholder "Type to search..."
+          , HP.id_ inputId
+          , HP.value sst.search ]
         )
       ]

--- a/src/Core/Validation.purs
+++ b/src/Core/Validation.purs
@@ -7,6 +7,7 @@ import Data.Foldable (class Foldable, length)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Eq (genericEq)
 import Data.Generic.Rep.Show (genericShow)
+import Data.Maybe (Maybe(..))
 import Data.String (null)
 import Data.Validation.Semigroup (V, invalid)
 import Halogen.HTML as HH
@@ -45,6 +46,10 @@ validateNonEmptyStr str
 validateNonEmptyArr :: ∀ a. Array a -> V ValidationErrors (Array a)
 validateNonEmptyArr [] = invalid $ pure EmptyField
 validateNonEmptyArr xs = pure xs
+
+validateNonEmptyMaybe :: ∀ a. Maybe a -> V ValidationErrors a
+validateNonEmptyMaybe (Just a) = pure a
+validateNonEmptyMaybe Nothing = invalid $ pure EmptyField
 
 validateStrIsEmail :: String -> V ValidationErrors String
 validateStrIsEmail email

--- a/ui-guide/Components/FormControl.purs
+++ b/ui-guide/Components/FormControl.purs
@@ -79,8 +79,9 @@ component =
                 { label: "Email"
                 , helpText: Just "Dave will spam your email with gang of four patterns"
                 , valid: Nothing
+                , inputId: "email"
                 }
-                ( Input.input [ HP.placeholder "davelovesdesignpatterns@gmail.com" ] )
+                ( Input.input [ HP.placeholder "davelovesdesignpatterns@gmail.com", HP.id_ "email" ] )
               ]
           ]
       , Documentation.documentation
@@ -95,8 +96,9 @@ component =
                 { label: "Dave's OO Emails"
                 , helpText: Just "Once enabled, you can never unsubscribe."
                 , valid: Nothing
+                , inputId: "toggle"
                 }
-                ( Toggle.toggle [] )
+                ( Toggle.toggle [ HP.id_ "toggle" ] )
               ]
           ]
 
@@ -122,6 +124,7 @@ component =
               { title: "Radio with Form Control" }
               [ FormControl.formControl
                   { label: "Platform"
+                  , inputId: "radio"
                   , helpText: Just "Where do you want your ad to appear?"
                   , valid: Nothing
                   }

--- a/ui-guide/Components/TextFields.purs
+++ b/ui-guide/Components/TextFields.purs
@@ -159,8 +159,9 @@ cnDocumentationBlocks =
           { label: "Developers"
           , helpText: Just "There are lots of developers to choose from."
           , valid: Nothing
+          , inputId: "devs"
           }
-          ( HH.slot' CP.cp3 unit TypeaheadCore.component (Typeahead.defMulti containerData Typeahead.renderItemString) (HE.input HandleSyncTypeahead) )
+          ( HH.slot' CP.cp3 unit TypeaheadCore.component (Typeahead.defMulti "devs" containerData Typeahead.renderItemString) (HE.input HandleSyncTypeahead) )
         ]
       , Component.component
         { title: "Continuous Asynchronous Typeahead" }
@@ -168,8 +169,9 @@ cnDocumentationBlocks =
           { label: "Developers"
           , helpText: Just "There are lots of developers to choose from."
           , valid: Nothing
+          , inputId: "devs-async"
           }
-          ( HH.slot' CP.cp1 unit TypeaheadCore.component (Typeahead.defContAsyncMulti Async.todos Async.renderItemTodo) (HE.input $ HandleTypeahead unit) )
+          ( HH.slot' CP.cp1 unit TypeaheadCore.component (Typeahead.defContAsyncMulti "devs-async" Async.todos Async.renderItemTodo) (HE.input $ HandleTypeahead unit) )
         ]
       ]
   , Documentation.documentation
@@ -182,6 +184,7 @@ cnDocumentationBlocks =
           { label: "Developers"
           , helpText: Just "There are lots of developers to choose from."
           , valid: Nothing
+          , inputId: ""
           }
           dropdownSingleSlot
         ]
@@ -191,6 +194,7 @@ cnDocumentationBlocks =
           { label: "Developers"
           , helpText: Just "There are lots of developers to choose from."
           , valid: Nothing
+          , inputId: ""
           }
           dropdownMultiSlot
         ]

--- a/ui-guide/Components/Validation.purs
+++ b/ui-guide/Components/Validation.purs
@@ -331,42 +331,50 @@ renderForm st =
           { label: "Developers"
           , helpText: Just "There are lots of developers to choose from."
           , valid: Map.lookup FailDevelopers st.errors
+          , inputId: "devs"
           }
-          ( HH.slot' CP.cp1 unit TA.component (TAInput.defMulti testRecords renderItemTestRecord) (HE.input HandleA) )
+          ( HH.slot' CP.cp1 unit TA.component (TAInput.defMulti "devs" testRecords renderItemTestRecord) (HE.input HandleA) )
         , FormControl.formControl
           { label: "Todos"
           , helpText: Just "Synchronous todo fetching like you've always wanted."
           , valid: Map.lookup FailTodos st.errors
+          , inputId: "todos"
           }
-          ( HH.slot' CP.cp2 unit TA.component (TAInput.defAsyncMulti Async.todos Async.renderItemTodo) (HE.input HandleB) )
+          ( HH.slot' CP.cp2 unit TA.component (TAInput.defAsyncMulti "todos" Async.todos Async.renderItemTodo) (HE.input HandleB) )
         , FormControl.formControl
           { label: "Users"
           , helpText: Just "Oh, you REALLY need async, huh."
           , valid: Map.lookup FailUsers1 st.errors
+          , inputId: "users1"
           }
-          ( HH.slot' CP.cp3 unit TA.component (TAInput.defContAsyncMulti Async.users Async.renderItemUser) (HE.input HandleC) )
+          ( HH.slot' CP.cp3 unit TA.component (TAInput.defContAsyncMulti "users1" Async.users Async.renderItemUser) (HE.input HandleC) )
         , FormControl.formControl
           { label: "Users 2"
           , helpText: Just "Honestly, this is just lazy."
           , valid: Map.lookup FailUsers2 st.errors
+          , inputId: "users2"
           }
-          ( HH.slot' CP.cp4 unit TA.component (TAInput.defAsyncMulti Async.users Async.renderItemUser) (HE.input HandleD) )
+          ( HH.slot' CP.cp4 unit TA.component (TAInput.defAsyncMulti "users2" Async.users Async.renderItemUser) (HE.input HandleD) )
         , FormControl.formControl
           { label: "Email"
           , helpText: Just "Dave will spam your email with gang of four patterns"
           , valid: Map.lookup FailEmail st.errors
+          , inputId: "email"
           }
           ( Input.input
             [ HP.placeholder "davelovesgangoffour@gmail.com"
+            , HP.id_ "email"
             , HE.onBlur (HE.input_ $ Validate FailEmail (EmailV st.raw.email))
             , HE.onValueInput (HE.input $ UpdateTextField 1) ] )
         , FormControl.formControl
           { label: "Username"
           , helpText: Just "Put your name in and we'll spam you forever"
           , valid: Map.lookup FailUsername st.errors
+          , inputId: "username"
           }
           ( Input.input
             [ HP.placeholder "Placehold me"
+            , HP.id_ "username"
             , HE.onBlur (HE.input_ $ Validate FailUsername (UsernameV st.raw.username))
             , HE.onValueInput (HE.input $ UpdateTextField 2) ] )
         , Button.button


### PR DESCRIPTION
This PR fixes our implementation of labels in form controls. Unfortunately, simply wrapping our inputs in the label element to provide an implicit association causes issues due to the fact that [clicking on a label triggers a click event on every element it's associated with](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label), which in the case of our components caused improper behavior (closing the selection container instead of selecting an element, removing elements when clicking the label, etc.)

This means that we have to use the `for` attribute to accomplish the association, which means we need to parameterize our form control block as well as our components by the input id. For now I've done that by adding a `String` parameter to each of the default typeahead configuration functions, and passed that along to the `renderTA` function which sticks that on the input inside the `renderSearch` function.

#### A few things to note
* I did not implement setting the `id` for our dropdown component because it's not currently using the form control block and I'm assuming it will change a bit
* Where does the `id` go for a group of radio buttons? On the containing `div`?
* For accessibility every form input should have a label, so maybe we should consider just adding the id as a parameter to our `input` function instead of needing to add it as a property to every form input manually